### PR TITLE
Implement support for ModelData and ModelDataManager

### DIFF
--- a/rendering/src/main/java/dev/compactmods/gander/render/geometry/LevelBakery.java
+++ b/rendering/src/main/java/dev/compactmods/gander/render/geometry/LevelBakery.java
@@ -81,15 +81,11 @@ public class LevelBakery {
         pose.pushPose();
         pose.translate(pos.getX(), pos.getY(), pos.getZ());
 
-        ModelData modelData = ModelData.EMPTY;
+        ModelData modelData;
         if (state.getRenderShape() == RenderShape.MODEL) {
             BakedModel model = dispatcher.getBlockModel(state);
 
-            if (state.hasBlockEntity()) {
-                BlockEntity blockEntity = level.getBlockEntity(pos);
-                modelData = blockEntity != null ? blockEntity.getModelData() : ModelData.EMPTY;
-            }
-
+            modelData = level.getModelData(pos);
             modelData = model.getModelData(level, pos, state, modelData);
 
             long seed = state.getSeed(pos);

--- a/testmod/src/main/java/dev/compactmods/gander/client/gui/ScreenOpener.java
+++ b/testmod/src/main/java/dev/compactmods/gander/client/gui/ScreenOpener.java
@@ -47,8 +47,12 @@ public class ScreenOpener {
 
 	public static void forStructureData(Component source, StructureTemplate data) {
 		openGanderUI(ui -> {
-			var virtualLevel = new VirtualLevel(Minecraft.getInstance().level.registryAccess(), true);
-			var bounds = data.getBoundingBox(new StructurePlaceSettings(), BlockPos.ZERO);
+            var bounds = data.getBoundingBox(new StructurePlaceSettings(), BlockPos.ZERO);
+            var virtualLevel = new VirtualLevel(Minecraft.getInstance().level.registryAccess(), true, (newLevel) -> {
+                var bakedLevel = LevelBakery.bakeVertices(newLevel, bounds, new Vector3f());
+                ui.setScene(bakedLevel);
+            });
+
 			virtualLevel.setBounds(bounds);
 			data.placeInWorld(virtualLevel, BlockPos.ZERO, BlockPos.ZERO, new StructurePlaceSettings().setKnownShape(true), RandomSource.create(), Block.UPDATE_CLIENTS);
 

--- a/testmod/src/main/java/dev/compactmods/gander/world/InWorldRenderer.java
+++ b/testmod/src/main/java/dev/compactmods/gander/world/InWorldRenderer.java
@@ -27,8 +27,15 @@ public class InWorldRenderer
 	public static void forStructureData(Component source, StructureTemplate data, Vector3f renderLocation) {
 		CommonEvents.setTitle(source);
 
-		var virtualLevel = new VirtualLevel(Minecraft.getInstance().level.registryAccess(), true);
-		var bounds = data.getBoundingBox(new StructurePlaceSettings(), BlockPos.ZERO);
+        var bounds = data.getBoundingBox(new StructurePlaceSettings(), BlockPos.ZERO);
+		var virtualLevel = new VirtualLevel(Minecraft.getInstance().level.registryAccess(), true, (newLevel) -> {
+            var bakedLevel = LevelBakery.bakeVertices(newLevel, bounds, new Vector3f());
+            var newRenderer = LevelInLevelRenderer.create(bakedLevel, newLevel, renderLocation);
+
+            //TODO: FIgure out how to override the existing LIL renderer
+            //GanderTestMod.addLevelInLevelRenderer(newRenderer);
+        });
+
 		virtualLevel.setBounds(bounds);
 		data.placeInWorld(virtualLevel, BlockPos.ZERO, BlockPos.ZERO, new StructurePlaceSettings().setKnownShape(true), RandomSource.create(), Block.UPDATE_CLIENTS);
 


### PR DESCRIPTION
### TLDR:
You were using the wrong ModelData as input for the model.
This corrects this.

#### ModelData
- Expose a ModelDataManager from a level, and overwrite the proper methods.
- Make the LevelBakery properly use the model data that is stored in it.

#### Change callback
- Added a change callback to VirtualLevel triggered when sendBlockUpdate is called upon it.
  - Needed to be ClientLevel compatible because a call to that level marks the section in which the update is triggered as needing a redraw.
  